### PR TITLE
Eng 669 fsgroup fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
     <properties>
         <github.organization>entando-k8s</github.organization>
         <sonar.projectKey>${github.organization}_${project.artifactId}</sonar.projectKey>
-        <entando.k8s.operator.common.version>6.1.7</entando.k8s.operator.common.version>
-        <entando.k8s.custom.model.version>6.1.4</entando.k8s.custom.model.version>
+        <entando.k8s.operator.common.version>6.1.9</entando.k8s.operator.common.version>
+        <entando.k8s.custom.model.version>6.1.5</entando.k8s.custom.model.version>
         <preDeploymentTestGroups>in-process-component</preDeploymentTestGroups>
         <postDeploymentTestGroups>end-to-end</postDeploymentTestGroups>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
     <properties>
         <github.organization>entando-k8s</github.organization>
         <sonar.projectKey>${github.organization}_${project.artifactId}</sonar.projectKey>
-        <entando.k8s.operator.common.version>6.1.2</entando.k8s.operator.common.version>
-        <entando.k8s.custom.model.version>6.1.3</entando.k8s.custom.model.version>
+        <entando.k8s.operator.common.version>6.1.7</entando.k8s.operator.common.version>
+        <entando.k8s.custom.model.version>6.1.4</entando.k8s.custom.model.version>
         <preDeploymentTestGroups>in-process-component</preDeploymentTestGroups>
         <postDeploymentTestGroups>end-to-end</postDeploymentTestGroups>
     </properties>


### PR DESCRIPTION
This PR is just bringing in the latest dependencies from custom-model and operator-common to ensure that state and environment variables are propagated correctly to delegate controller. It doesn't affect the behaviour of the image at all.